### PR TITLE
Added Pushbullet notifications for errors

### DIFF
--- a/PushbulletModule.psm1
+++ b/PushbulletModule.psm1
@@ -1,0 +1,52 @@
+# Set the environment variables from the .env file
+Get-Content .env | ForEach-Object {
+  $name, $value = $_.split('=')
+  Set-Content env:\$name $value
+}
+
+<#
+.DESCRIPTION
+  Sends a Pushbullet note with the specified title and body to all devices
+#>
+function Send-PushbulletNote {
+  [CmdletBinding()]
+  param (
+    [String]$Title,
+    [String]$Body
+  )
+  [String]$pushbulletAccessToken = $Env:PUSHBULLET_ACCESS_TOKEN
+  if ([string]::IsNullOrEmpty($pushbulletAccessToken)) {
+    Write-Output "No environment variable set for PUSHBULLET_ACCESS_TOKEN"
+    return
+  }
+
+  try {
+    [bool]$isVerbose = $PSBoundParameters['Verbose'] -eq $True
+
+    # An error will be thrown from the curl command if single quotes aren't escaped properly
+    [String]$escapedBody = $Body -replace "'", "''" 
+    [String]$escapedTitle = $Title -replace "'", "''" 
+
+    [String]$command = "curl --header 'Access-Token: $pushbulletAccessToken' --header 'Content-Type: application/json' --data-binary '{""body"":""$escapedBody"",""title"":""$escapedTitle"", ""type"":""note""}' --request POST https://api.pushbullet.com/v2/pushes"
+
+    Write-Verbose "Sending Pushbullet with title '$escapedTitle' and body '$escapedBody'"
+    if ($isVerbose) {
+      $response = Invoke-Expression $command | Out-String
+      Write-Verbose $response
+    }
+    else {
+      $response = Invoke-Expression "$command --silent" | Out-String
+    }
+    
+    # Throw an error if an error object is returned in the response body
+    $responseObject = ConvertFrom-JSON -InputObject $response
+    if ($responseObject | Get-Member -Name "error") {
+      throw "$($responseObject.error.code): $($responseObject.error.message)"
+    }
+  }
+  catch {
+    # Log error but don't rethrow
+    Write-Host "Error: could not send Pushbullet note" -ForegroundColor Yellow
+    Write-Host $_ -ForegroundColor Yellow
+  }
+} 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Quick and dirty implementation of a command line application to flash between tw
    HUE_SCENE_ID_COLOR1=id-of-first-color
    HUE_SCENE_ID_COLOR1=id-of-second-color
    ```
+4. (Optional) This application is set up to optionally send a pushbullet notification to all devices if an error occurs. Create an access token for your Pushbullet account, then add it to the `.env` file.
+   ```
+   PUSHBULLET_ACCESS_TOKEN=pushbullet-access-token
+   ```
 
 ## Run
 

--- a/Start-TeamListener.ps1
+++ b/Start-TeamListener.ps1
@@ -13,13 +13,13 @@ param(
 Import-Module ./HueModule.psm1
 
 [bool]$isVerbose = $PSBoundParameters['Verbose'] -eq $True
-[String]$today = Get-Date -Format "yyyyMMdd"
-[String]$url = "https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard?dates=$today"
 
 Write-Verbose "Url: $url"
 $previousScore = 0;
 while ($True) {
   try {
+    [String]$today = Get-Date -Format "yyyyMMdd"
+    [String]$url = "https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard?dates=$today"
     $response = Invoke-RestMethod -Uri $url -Method Get
     $events = $response.events
     $eventFound = $False

--- a/Start-TeamListener.ps1
+++ b/Start-TeamListener.ps1
@@ -6,11 +6,12 @@
 #>
 [CmdletBinding()]
 param(
-  [Parameter(Mandatory = $True, HelpMessage="Enter the NFL team abbreviation. Ex. 'PHI'")]
+  [Parameter(Mandatory = $True, HelpMessage = "Enter the NFL team abbreviation. Ex. 'PHI'")]
   [String]$TeamAbbreviation
 )
 
 Import-Module ./HueModule.psm1
+Import-Module ./PushbulletModule.psm1
 
 [bool]$isVerbose = $PSBoundParameters['Verbose'] -eq $True
 
@@ -56,7 +57,6 @@ while ($True) {
         # Throw error if team wasn't found
         # Edge case that isn't expected to be hit since there's already a check for the team in the event name
         if (!$teamFound) {
-          Write-Output $competitors
           throw "Team '$TeamAbbreviation' could not be found in competitors for event id $($event.id)"
         }
 
@@ -67,15 +67,16 @@ while ($True) {
 
     # Throw error if the event wasn't found
     if (!$eventFound) {
-      Write-Output $events
       throw "Event for '$TeamAbbreviation' could not be found on $today"
     }
 
     # Wait 10 seconds
     Start-Sleep -Seconds 10
   }
-  catch {  
-    Write-Host $_ -ForegroundColor Red # Log error
+  catch {
+    $errorMessage = $_
+    Send-PushbulletNote -Title "Score Lights Error" -Body $errorMessage -Verbose:$isVerbose
+    Write-Host $errorMessage -ForegroundColor Red # Log error
     exit 1
   }
 }


### PR DESCRIPTION
Added Pushbullet notifications for errors.

Pushbullet notification is sent in the background when there's an error in the application:
![image](https://github.com/user-attachments/assets/5604095e-9c79-4233-a81c-65467abff772)

If the token is not set in the `.env`:
![image](https://github.com/user-attachments/assets/19a6b939-daa7-4172-907e-72cfded245e7)

Error handling if the pushbullet call fails:
![image](https://github.com/user-attachments/assets/a90fa658-3c10-465a-8456-4c492844a8cb)
